### PR TITLE
Changed image metadata update endpoint to have opusId parameter

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-profileServiceVersion=5.2
+profileServiceVersion=5.2.1-SNAPSHOT
 grailsVersion=5.2.4
 gorm.version=7.3.2
 groovyVersion=3.0.11

--- a/grails-app/controllers/au/org/ala/profile/ImageController.groovy
+++ b/grails-app/controllers/au/org/ala/profile/ImageController.groovy
@@ -18,9 +18,10 @@ class ImageController extends BaseController {
 
     def updateMetadata() {
         String imageId = params.imageId
+        String opusId = params.opusId
         final metadata = request.getJSON()
-        if (!imageId || !metadata) {
-            badRequest "imageId and request body are required parameters"
+        if (!opusId || !imageId || !metadata) {
+            badRequest "opusId, imageId and request body are required parameters"
         } else {
             def image = localImageService.updateMetadata(imageId, metadata)
             render image as JSON

--- a/grails-app/controllers/au/org/ala/profile/UrlMappings.groovy
+++ b/grails-app/controllers/au/org/ala/profile/UrlMappings.groovy
@@ -118,6 +118,9 @@ class UrlMappings {
         "/opus/$opusId/restore/$profileId" controller: "profile", action: [POST: "restoreArchivedProfile"]
         "/opus/$opusId/reindex" controller: "opus", action: [POST: "reindex"]
 
+        "/opus/$opusId/image/$imageId/metadata" controller: "image", action: [GET: "getImageInfo", POST: "updateMetadata"]
+        "/image/$imageId" controller: "image", action: [GET: "getImageInfo"]
+
         "/checkName" controller: "profile", action: [GET: "checkName"]
 
         "/report/archivedProfiles" controller: "report", action: [GET: "archivedProfiles"]
@@ -130,9 +133,6 @@ class UrlMappings {
         "/job/$jobType/$jobId" controller: "job", action: [DELETE: "deleteJob", POST: "updateJob"]
         "/job/$jobType" controller: "job", action: [GET: "listAllPendingJobs", PUT: "createJob"]
         "/job/" controller: "job", action: [GET: "listAllPendingJobs", PUT: "createJob"]
-
-        "/image/$imageId" controller: "image", action: [GET: "getImageInfo"]
-        "/image/$imageId/metadata" controller: "image", action: [GET: "getImageInfo", POST: "updateMetadata"]
 
         "/statistics/" controller: "statistics", action: [GET: "index"]
 


### PR DESCRIPTION
Fixes AtlasOfLivingAustralia/profile-hub#809 by adding the `opusId` parameter to the request URL